### PR TITLE
Update Dockerfile

### DIFF
--- a/docker-registry/registry/Dockerfile
+++ b/docker-registry/registry/Dockerfile
@@ -1,3 +1,5 @@
 FROM registry:2.5.1
 
 COPY custom-entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
prevent error in the container

without this, the build process throws this ugly error:

ERROR: for privatereg_registry_1 Cannot start service registry: oci runtime error: container_linux.go:247: starting container process caused "exec: \"/entrypoint.sh\": permission denied"